### PR TITLE
Align scoreboard games in 2x4 matrix

### DIFF
--- a/MMM-MLBScoresAndStandings.css
+++ b/MMM-MLBScoresAndStandings.css
@@ -77,8 +77,15 @@
 /*--------------------------------------------------
   Scoreboard Grid
 --------------------------------------------------*/
-.games-columns { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; justify-items: center; }
-.game-col { display: flex; flex-direction: column; gap: 6px; }
+.games-matrix {
+  border-collapse: separate;
+  border-spacing: 8px;
+  margin: 0 auto;
+}
+
+.games-matrix-cell {
+  vertical-align: top;
+}
 
 /*--------------------------------------------------
   BOX SCORE: STATIC LAYOUT (nth-child widths + fixed heights)

--- a/MMM-MLBScoresAndStandings.js
+++ b/MMM-MLBScoresAndStandings.js
@@ -202,23 +202,29 @@
       var start = this.currentScreen * this.config.gamesPerPage;
       var games = this.games.slice(start, start + this.config.gamesPerPage);
 
-      var wrapper = document.createElement("div");
-      wrapper.className = "games-columns";
+      var matrix = document.createElement("table");
+      matrix.className = "games-matrix";
 
-      var half = Math.ceil(games.length / 2);
-      var left = games.slice(0, half);
-      var right = games.slice(half);
+      var tbody = document.createElement("tbody");
 
-      var cols = [left, right];
-      for (var c = 0; c < cols.length; c++) {
-        var colDiv = document.createElement("div");
-        colDiv.className = "game-col";
-        for (var i = 0; i < cols[c].length; i++) {
-          colDiv.appendChild(this.createGameBox(cols[c][i]));
+      for (var i = 0; i < games.length; i += 2) {
+        var row = document.createElement("tr");
+
+        for (var col = 0; col < 2; col++) {
+          var cell = document.createElement("td");
+          cell.className = "games-matrix-cell";
+
+          var game = games[i + col];
+          if (game) cell.appendChild(this.createGameBox(game));
+
+          row.appendChild(cell);
         }
-        wrapper.appendChild(colDiv);
+
+        tbody.appendChild(row);
       }
-      return wrapper;
+
+      matrix.appendChild(tbody);
+      return matrix;
     },
 
     // STATIC 4-COLUMN BOX SCORE (status/team, R, H, E)


### PR DESCRIPTION
## Summary
- rebuild the scoreboard view so games are arranged in a two-column table grid
- adjust scoreboard CSS to center the matrix and keep consistent spacing between cells

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6bf460f7c8322adf8ab74b2315c55