### PR TITLE
Ensure scoreboard renders fixed 2x4 grid

### DIFF
--- a/MMM-MLBScoresAndStandings.css
+++ b/MMM-MLBScoresAndStandings.css
@@ -27,6 +27,7 @@
   --box-border: 1px solid #444;
   --box-live:   #FFD242;
   --box-text:   #FFF;
+  --box-slot-height: calc(var(--box-header-height) + (2 * var(--box-square)) + 6px);
 
   /* ===== Standings ===== */
   --font-size-standings-headers: 1.0em;
@@ -77,8 +78,31 @@
 /*--------------------------------------------------
   Scoreboard Grid
 --------------------------------------------------*/
-.games-columns { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; justify-items: center; }
-.game-col { display: flex; flex-direction: column; gap: 6px; }
+.games-matrix {
+  border-collapse: separate;
+  border-spacing: 12px 10px;
+  margin: 0 auto;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.games-matrix-cell {
+  vertical-align: top;
+  width: 50%;
+  text-align: center;
+  padding: 0;
+}
+
+.games-matrix-cell.empty::before {
+  content: "";
+  display: inline-block;
+  width: calc(var(--box-col-first) + (3 * var(--box-square)) + var(--box-width-buffer));
+  height: var(--box-slot-height);
+}
+
+.games-matrix-cell > .game-boxscore {
+  margin: 0 auto;
+}
 
 /*--------------------------------------------------
   BOX SCORE: STATIC LAYOUT (nth-child widths + fixed heights)

--- a/MMM-MLBScoresAndStandings.js
+++ b/MMM-MLBScoresAndStandings.js
@@ -202,23 +202,40 @@
       var start = this.currentScreen * this.config.gamesPerPage;
       var games = this.games.slice(start, start + this.config.gamesPerPage);
 
-      var wrapper = document.createElement("div");
-      wrapper.className = "games-columns";
+      var matrix = document.createElement("table");
+      matrix.className = "games-matrix";
 
-      var half = Math.ceil(games.length / 2);
-      var left = games.slice(0, half);
-      var right = games.slice(half);
+      var tbody = document.createElement("tbody");
 
-      var cols = [left, right];
-      for (var c = 0; c < cols.length; c++) {
-        var colDiv = document.createElement("div");
-        colDiv.className = "game-col";
-        for (var i = 0; i < cols[c].length; i++) {
-          colDiv.appendChild(this.createGameBox(cols[c][i]));
+      var columns = 2;
+      var perPage = this.config.gamesPerPage || 8;
+      var rows = Math.max(1, Math.ceil(perPage / columns));
+      var totalSlots = rows * columns;
+
+      for (var slot = 0; slot < totalSlots; slot += columns) {
+        var row = document.createElement("tr");
+
+        for (var col = 0; col < columns; col++) {
+          var cell = document.createElement("td");
+          cell.className = "games-matrix-cell";
+
+          var idx = slot + col;
+          var game = games[idx];
+
+          if (game) {
+            cell.appendChild(this.createGameBox(game));
+          } else {
+            cell.classList.add("empty");
+          }
+
+          row.appendChild(cell);
         }
-        wrapper.appendChild(colDiv);
+
+        tbody.appendChild(row);
       }
-      return wrapper;
+
+      matrix.appendChild(tbody);
+      return matrix;
     },
 
     // STATIC 4-COLUMN BOX SCORE (status/team, R, H, E)


### PR DESCRIPTION
## Summary
- enforce a fixed two-column scoreboard grid that always renders all eight slots per page
- update scoreboard styling so empty slots preserve spacing and the matrix centers correctly

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6bf460f7c8322adf8ab74b2315c55