### PR TITLE
Fix scoreboard layout to 4x3 grid

### DIFF
--- a/MMM-MLBScoresAndStandings.css
+++ b/MMM-MLBScoresAndStandings.css
@@ -93,7 +93,7 @@
 
 .games-matrix-cell {
   vertical-align: top;
-  width: 50%;
+  width: 25%;
   text-align: center;
   padding: 0;
 }

--- a/MMM-MLBScoresAndStandings.js
+++ b/MMM-MLBScoresAndStandings.js
@@ -17,6 +17,11 @@
     "Athletics": "ATH","Seattle Mariners": "SEA","Texas Rangers": "TEX"
   };
 
+  // Scoreboard layout
+  var SCOREBOARD_COLUMNS = 4;
+  var SCOREBOARD_ROWS    = 3;
+  var GAMES_PER_PAGE     = SCOREBOARD_COLUMNS * SCOREBOARD_ROWS;
+
   // Division pairs (2 per page), then Wild Card pages (1 per page)
   var DIV_PAIRS = [
     [204, 201], // NL East & AL East
@@ -37,7 +42,7 @@
     defaults: {
       updateIntervalScores:            60 * 1000,
       updateIntervalStandings:       15 * 60 * 1000,
-      gamesPerPage:                      8,
+      gamesPerPage:                      GAMES_PER_PAGE,
       logoType:                      "color",
       rotateIntervalScores:           15 * 1000,
       rotateIntervalEast:              7 * 1000,
@@ -147,7 +152,7 @@
         if (notification === "GAMES") {
           this.loadedGames    = true;
           this.games          = Array.isArray(payload) ? payload : [];
-          this.totalGamePages = Math.max(1, Math.ceil(this.games.length / this.config.gamesPerPage));
+          this.totalGamePages = Math.max(1, Math.ceil(this.games.length / GAMES_PER_PAGE));
           this.updateDom();
         }
         if (notification === "STANDINGS") {
@@ -199,22 +204,23 @@
 
     // ----------------- SCOREBOARD -----------------
     _buildGames: function () {
-      var start = this.currentScreen * this.config.gamesPerPage;
-      var games = this.games.slice(start, start + this.config.gamesPerPage);
+      var start = this.currentScreen * GAMES_PER_PAGE;
+      var games = this.games.slice(start, start + GAMES_PER_PAGE);
 
       var matrix = document.createElement("table");
       matrix.className = "games-matrix";
 
       var tbody = document.createElement("tbody");
 
-      for (var i = 0; i < games.length; i += 2) {
+      for (var r = 0; r < SCOREBOARD_ROWS; r++) {
         var row = document.createElement("tr");
 
-        for (var col = 0; col < 2; col++) {
+        for (var c = 0; c < SCOREBOARD_COLUMNS; c++) {
           var cell = document.createElement("td");
           cell.className = "games-matrix-cell";
 
-          var game = games[i + col];
+          var index = r * SCOREBOARD_COLUMNS + c;
+          var game = games[index];
           if (game) {
             cell.appendChild(this.createGameBox(game));
           } else {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It rotates between game scoreboards and standings (division pairs and wild cards
 
 ## Features
 
-- **Scoreboard** in two balanced columns, `gamesPerPage` paginated.
+- **Scoreboard** uses a fixed 4 × 3 grid (12 slots) per page.
 - **Standings** cycle: NL/AL East, NL/AL Central, NL/AL West, NL Wild Card, AL Wild Card.
 - **Wild Card**: division leaders are excluded; WCGB computed vs. the 3rd WC team.
 - **“GB / WCGB / E#”**: `0` rendered as `--`; half-games show as `1/2` in smaller type.
@@ -83,7 +83,7 @@ Add to your `config/config.js`:
     updateIntervalStandings: 15 * 60 * 1000,
 
     // Scoreboard
-    gamesPerPage: 8,
+    gamesPerPage: 12,        // fixed 4 × 3 scoreboard (12 slots per page)
     logoType: "color",         // folder under ./logos/ e.g. logos/color/ATL.png
     rotateIntervalScores: 15 * 1000,
 
@@ -110,6 +110,7 @@ Add to your `config/config.js`:
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
 - **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]`.
 - The rotation order is fixed as: *Scoreboard → (NL/AL East) → (NL/AL Central) → (NL/AL West) → NL WC → AL WC*.
+- The scoreboard always renders in a 4 × 3 grid (12 slots) per page; the config value is kept for clarity.
 
 ---
 


### PR DESCRIPTION
## Summary
- force the scoreboard pagination to use a 4 × 3 grid layout with 12 slots per page
- adjust the grid cell styling so four games render per row
- document the fixed layout in the README configuration guidance

## Testing
- not run (UI layout change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6f4b5ad9c8322ab0bd617f1e6858d