### PR TITLE
Add scoreboard logos and configurable standings pages

### DIFF
--- a/MMM-MLBScoresAndStandings.css
+++ b/MMM-MLBScoresAndStandings.css
@@ -34,8 +34,8 @@
   --scoreboard-border-live:  #c3941a;
   --scoreboard-card-radius:  12px;
   --scoreboard-card-shadow:  0 6px 12px rgba(0, 0, 0, 0.45);
-  --scoreboard-background:   rgba(10, 10, 10, 0.95);
-  --scoreboard-header-bg:    rgba(18, 18, 18, 0.95);
+  --scoreboard-background:   transparent;
+  --scoreboard-header-bg:    transparent;
   --scoreboard-text:         #ffffff;
   --scoreboard-muted:        #8c8c8c;
   --scoreboard-value-color:  #ffd242;
@@ -196,7 +196,7 @@
 }
 
 .scoreboard-card .scoreboard-body {
-  background: rgba(8, 8, 8, 0.95);
+  background: transparent;
   display: flex;
   flex-direction: column;
 }
@@ -211,6 +211,19 @@
 }
 
 .scoreboard-card .scoreboard-team {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--scoreboard-team-font) * 0.25);
+}
+
+.scoreboard-card .scoreboard-team-logo {
+  height: calc(var(--scoreboard-team-font) * 0.8);
+  max-height: calc(var(--scoreboard-team-font) * 0.9);
+  width: auto;
+  display: block;
+}
+
+.scoreboard-card .scoreboard-team-abbr {
   font-size: var(--scoreboard-team-font);
   letter-spacing: 0.12em;
   text-transform: uppercase;

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Add to your `config/config.js`:
     updateIntervalStandings: 15 * 60 * 1000,
 
     // Scoreboard layout
-    scoreboardColumns: 1,     // number of columns of game boxes per page
-    gamesPerColumn: 4,        // games stacked in each column
+    scoreboardColumns: 2,     // number of columns of game boxes per page
+    gamesPerColumn: 2,        // games stacked in each column
     // (optional) gamesPerPage: 8, // override derived columns × gamesPerColumn
     logoType: "color",         // folder under ./logos/ e.g. logos/color/ATL.png
     layoutScale: 0.9,          // shrink (<1) or grow (>1) everything at once (clamped 0.6 – 1.4)
@@ -103,6 +103,8 @@ Add to your `config/config.js`:
 
     // NEW: standings Home/Away splits
     showHomeAwaySplits: true,   // set false to hide "Home" & "Away" columns
+    showDivisionStandings: true,
+    showWildCardStandings: true,
 
     // Width cap to keep module tidy in middle_center
     maxWidth: "720px"
@@ -114,11 +116,12 @@ Add to your `config/config.js`:
 - **Header width** matches `maxWidth` and stays in the default MM font (Roboto Condensed).
 - **Highlighted teams** accept a single string `"CUBS"` or an array like `["CUBS","NYY"]`.
 - **layoutScale** is the quickest way to fix oversize boxes—values below `1` compact the layout.
-- The rotation order is fixed as: *Scoreboard → (NL/AL East) → (NL/AL Central) → (NL/AL West) → NL WC → AL WC*.
-- By default the scoreboard renders one column with four games. Adjust `scoreboardColumns`
-  and `gamesPerColumn` to fit your layout (e.g., `scoreboardColumns: 2` keeps four games per
-  column for eight total per page). You can still provide `gamesPerPage` to override the
-  derived total if needed.
+- When both standings views are enabled the rotation order is *Scoreboard → (NL/AL East) →
+  (NL/AL Central) → (NL/AL West) → NL WC → AL WC*. Pages you disable are skipped entirely.
+- The default scoreboard layout now shows **two columns and up to four games** at a time.
+  Adjust `scoreboardColumns`, `gamesPerColumn`, or `gamesPerPage` to taste.
+- Toggle `showDivisionStandings` or `showWildCardStandings` to hide those pages entirely if
+  you only care about one view.
 
 ---
 


### PR DESCRIPTION
## Summary
- default the scoreboard to two columns with four games, add team logos, and remove the gray card background
- allow division and wild card standings pages to be toggled via new configuration flags
- refresh the documentation to describe the new defaults and configuration options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d83205a52083228f91ff934fae6fe5